### PR TITLE
Feat: Force Tooltip Inside Viewport Option

### DIFF
--- a/scenes/panels/panel.tscn
+++ b/scenes/panels/panel.tscn
@@ -4,5 +4,6 @@
 z_index = 10
 offset_right = 400.0
 offset_bottom = 100.0
-size_flags_horizontal = 2
-size_flags_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+mouse_filter = 2

--- a/scripts/tooltip_pal.gd
+++ b/scripts/tooltip_pal.gd
@@ -8,6 +8,7 @@ extends Control
 enum DirectionEnum {UP, RIGHT, DOWN, LEFT}
 @export var direction: DirectionEnum
 @export var directionalMargin: int
+@export var forceInBounds: bool
 
 # TODO: implement
 @export var hover_time: float
@@ -40,6 +41,21 @@ func determineShift(direction: DirectionEnum, directionalMargin: int, tooltip_pa
 
 	return directionShift + marginalShift
 
+# Repositions the tooltip's global position to remain within the viewport.
+func forceInsideViewport(tooltip):
+	# Calculate end position now for readability sake.
+	var tooltipEndPos = tooltip.global_position + tooltip.size
+
+	# Setting global position because we are working relative to the viewport.
+	if tooltip.global_position.x < 0: 
+		tooltip.global_position.x = 0
+	if tooltip.global_position.y < 0: 
+		tooltip.global_position.y = 0
+	if tooltipEndPos.x > get_viewport_rect().size.x: 
+		tooltip.global_position.x = get_viewport_rect().size.x - tooltip.size.x
+	if tooltipEndPos.y > get_viewport_rect().size.y:
+		tooltip.global_position.y = get_viewport_rect().size.y - tooltip.size.y
+
 func _on_mouse_entered():
 	tooltip = panel.instantiate() as Control
 	
@@ -48,11 +64,15 @@ func _on_mouse_entered():
 		pass
 	else:
 		position_from = get_parent()
-	determineShift(direction, directionalMargin, tooltip.size, position_from.size)
-		
+	
 	tooltip.global_position = determineShift(direction, directionalMargin, tooltip.size, position_from.size)
-
+	
 	position_from.add_child(tooltip)
+	
+	# Must do this repositioning after we have added it to the tree.
+	if forceInBounds: 
+		forceInsideViewport(tooltip)
+		
 	pass
 
 func _on_mouse_exited():


### PR DESCRIPTION
+ Add: Option, and function that repositions the tooltip inside the viewport.
~ Change: Set Panel.tscn to ignore mouse by default, so the tooltip doesn't flicker when drawn where the mouse is.
- Remove: determineShift() had a redundant call inside on_mouse_enter().

I had to put the forceInsideViewport() function call after the tooltip is added as a child, for some unknown reason doing it beforehand gave weird results. I think it has to do with setting the global_position, then trying to use that new position and change it again. But needs further debugging.

Either way it works as is, and I'll leave it up to you if the architecture worth is fussing over.