### PR TITLE
Feat: Use Parent Rect

### DIFF
--- a/scripts/tooltip_pal.gd
+++ b/scripts/tooltip_pal.gd
@@ -8,7 +8,10 @@ extends Control
 enum DirectionEnum {UP, RIGHT, DOWN, LEFT}
 @export var direction: DirectionEnum
 @export var directionalMargin: int
+## When enabled, keeps the tooltip inside the viewport
 @export var forceInBounds: bool
+## Uses the parent rect as the hover activator instead of this rect.
+@export var useParentRect : bool = true
 
 # TODO: implement
 @export var hover_time: float
@@ -19,7 +22,22 @@ var tooltip: Control
 func _ready():
 	connect("mouse_entered", _on_mouse_entered)
 	connect("mouse_exited", _on_mouse_exited)
+	switch_to_parent_rect(useParentRect)
 	pass
+
+# Changes hover activator rect to parent or self.
+func switch_to_parent_rect(value: bool):
+	if value:
+			get_parent().connect("mouse_entered", _on_mouse_entered)
+			get_parent().connect("mouse_exited", _on_mouse_exited)
+			mouse_filter = Control.MOUSE_FILTER_IGNORE
+	else:
+		# Need to check if there is a connection to prevent Error out.
+		if get_parent().is_connected("mouse_entered", _on_mouse_entered): 
+			get_parent().disconnect("mouse_entered", _on_mouse_entered)
+		if get_parent().is_connected("mouse_exited", _on_mouse_exited):
+			get_parent().disconnect("mouse_exited", _on_mouse_exited)
+		mouse_filter = Control.MOUSE_FILTER_STOP
 
 func determineShift(direction: DirectionEnum, directionalMargin: int, tooltip_panel: Vector2, parent: Vector2) -> Vector2:
 	var directionShift = Vector2(0,0)


### PR DESCRIPTION
Allows users to use the TooltipPal's parent rect as the hover activator.

I don't think the best way to do this is by forcing sizing changes within the editor.

The closer I got to implementing this, the more engine limitations were in my way:
- How would we handle resizing done in game?
- Should we prevent resizing in the editor if this option is enabled?

Instead of forcing the engine to do what we want I realized we should be working with the engine instead, and the solution was much simpler.

**_We keep the TooltipPal's rect independent of the parents._**

Instead, I wrote a simple function that essentially overrides the TooltipPal's mouse_entered and mouse_exited signals by connecting the parents mouse_entered and mouse_exited signals to the TooltipPal node, and set it's mouse_filter to ignore.

_PS: Also added tooltips for my exported variables._